### PR TITLE
feat: add setTextHint function to customize DropdownButton hint text

### DIFF
--- a/lib/country_state_picker.dart
+++ b/lib/country_state_picker.dart
@@ -161,7 +161,7 @@ class _CountryStatePickerState extends State<CountryStatePicker> {
                           ),
                         ],
                       )
-                    : const Text("Choose Country"),
+                    : setTextHint('Choose Country'),
                 dropdownColor: widget.dropdownColor ?? Colors.grey.shade100,
                 elevation: widget.elevation ?? 0,
                 isExpanded: widget.isExpanded ?? true,
@@ -231,7 +231,7 @@ class _CountryStatePickerState extends State<CountryStatePicker> {
                           ),
                         ],
                       )
-                    : const Text("Choose State"),
+                    : setTextHint('Choose State'),
                 dropdownColor: widget.dropdownColor ?? Colors.grey.shade100,
                 elevation: widget.elevation ?? 0,
                 isExpanded: widget.isExpanded ?? true,
@@ -274,4 +274,9 @@ class _CountryStatePickerState extends State<CountryStatePicker> {
       ],
     );
   }
+}
+
+// RETURN A TEXT WIDGET
+Widget setTextHint(String text) {
+  return Text(text);
 }


### PR DESCRIPTION
Added a new function called `setTextHint` that takes a `String` parameter and returns a `Text` widget. I replaced the previous hardcoded hint text `'Choose Country'` and `'Choose State'` with calls to the `setTextHint` function, passing in the appropriate text as an argument.

This change allows to easily customize the hint text for the `DropdownButton` widgets by modifying the `setTextHint` function. For example, now it is easier to change the style of the hint text by setting the `style` property of the `Text` widget returned by the `setTextHint` function.